### PR TITLE
Add CITATION file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## PSMatch 1.13.2
 
+- Add CITATION to the pre-print (https://doi.org/10.31219/osf.io/62v9p_v2)
 - Add possibility to split protein groups in PSM data with `makeAdjacencyMatrix`
 (see [issue #30](https://github.com/rformassspectrometry/PSMatch/issues/30))
 - Removed `showDetails()` from `setMethod("show", "PSM")` as discussed in 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -8,8 +8,8 @@ citEntry(entry = "Manual",
            person(given = "Laurent", family = "Gatto")),
          institution = "OSF",
          year = "2025",
-         doi = "https://doi.org/10.31219/osf.io/62v9p_v1",
+         doi = "https://doi.org/10.31219/osf.io/62v9p_v2",
          textVersion = paste("G. Deflandre, S. Gibbs and L. Gatto.",
                              "PSMatch: an R/Bioconductor package to explore proteomics identification data.",
-                             "OSF; doi: https://doi.org/10.31219/osf.io/62v9p_v1")
+                             "OSF; doi: https://doi.org/10.31219/osf.io/62v9p_v2")
          )


### PR DESCRIPTION
As per #35 , an added CITATION file to the package. 

I set the entry type as `Manual`. In case the preprint is published as part of a book, this might have to change to `inBook`.