### PR TITLE
docs: added clarifications on the use of addCarbamidomethyl = TRUE  default

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -40,7 +40,7 @@ env:
   run_pkgdown: 'true'
   has_RUnit: 'false'
   has_BiocCheck: 'false'
-  cache-version: 'cache-v4'
+  cache-version: 'cache-v3'
 
 jobs:
   build-check:

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -40,7 +40,7 @@ env:
   run_pkgdown: 'true'
   has_RUnit: 'false'
   has_BiocCheck: 'false'
-  cache-version: 'cache-v3'
+  cache-version: 'cache-v4'
 
 jobs:
   build-check:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## PSMatch 1.15.3
 
+- Adjusted documentation on `addCarbamidomethyl = TRUE` in
+`calculateFragments()` set by default.
 - Corrected `plotSpectraPTM()` relative `PTMods` dependencies, identifications
 are highlighted in bold in the USI. Added parameters to call addFixed and
 addVariable within `plotSpectraPTM()`.

--- a/R/plotSpectra-PTM.R
+++ b/R/plotSpectra-PTM.R
@@ -81,10 +81,9 @@
 ##' set `addCarbamidomethylation = FALSE`. For more
 ##' details on this, see the appropriate vignette by running
 ##' `vignette("Fragments", package = "PSMatch")
-
 ##'
 ##' @param ... additional parameters to be passed to the `labelFragments()`
-##'     and as such, `calculateFragments()` functions.
+##'     and `calculateFragments()` functions.
 ##'
 ##' @importFrom graphics layout par
 ##'

--- a/R/plotSpectra-PTM.R
+++ b/R/plotSpectra-PTM.R
@@ -78,7 +78,7 @@
 ##' carbamidomethylation as a fixed modification unless carbamidomethyl is
 ##' already present in the given sequences.
 ##' If carbamidomethylation should be applied as a variable modification, do
-##' call an extra parameter `addCarbamidomethylation = FALSE`. For more
+##' set `addCarbamidomethylation = FALSE`. For more
 ##' details on this, see the appropriate vignette by running
 ##' `vignette("Fragments", package = "PSMatch")
 

--- a/R/plotSpectra-PTM.R
+++ b/R/plotSpectra-PTM.R
@@ -72,10 +72,14 @@
 ##' @param variableModifications Named `numeric` or `character`, passed to
 ##'     `PTMods::addVariableModifications()`. Each unique combination of
 ##'     variable modifications generates a separate copy of the corresponding
-##'     spectrum. `NULL` by default (no variable modifications applied).
+##'     spectrum. `NULL` by default (no variable modifications applied). If
+##'     carbamidomethylation should be applied as a variable modification, do
+##'     call an extra parameter `addCarbamidomethylation = FALSE`. For more
+##'     details on this, see the appropriate vignette by running
+##'     `vignette("Fragments", package = "PSMatch")`
 ##'
 ##' @param ... additional parameters to be passed to the `labelFragments()`
-##'     function.
+##'     and as such, `calculateFragments()` functions.
 ##'
 ##' @importFrom graphics layout par
 ##'

--- a/R/plotSpectra-PTM.R
+++ b/R/plotSpectra-PTM.R
@@ -72,11 +72,16 @@
 ##' @param variableModifications Named `numeric` or `character`, passed to
 ##'     `PTMods::addVariableModifications()`. Each unique combination of
 ##'     variable modifications generates a separate copy of the corresponding
-##'     spectrum. `NULL` by default (no variable modifications applied). If
-##'     carbamidomethylation should be applied as a variable modification, do
-##'     call an extra parameter `addCarbamidomethylation = FALSE`. For more
-##'     details on this, see the appropriate vignette by running
-##'     `vignette("Fragments", package = "PSMatch")`
+##'     spectrum. `NULL` by default (no variable modifications applied).
+##'
+##' @param addCarbamidomethyl logical(1L) set to `TRUE` by default. Applies
+##' carbamidomethylation as a fixed modification unless carbamidomethyl is
+##' already present in the given sequences.
+##' If carbamidomethylation should be applied as a variable modification, do
+##' call an extra parameter `addCarbamidomethylation = FALSE`. For more
+##' details on this, see the appropriate vignette by running
+##' `vignette("Fragments", package = "PSMatch")
+
 ##'
 ##' @param ... additional parameters to be passed to the `labelFragments()`
 ##'     and as such, `calculateFragments()` functions.
@@ -167,6 +172,7 @@ plotSpectraPTM <- function(x, deltaMz = TRUE, ppm = 20,
                            asp = 1, minorTicks = TRUE, USI = TRUE,
                            fixedModifications = NULL,
                            variableModifications = NULL,
+                           addCarbamidomethyl = TRUE,
                            ...) {
     if (!("sequence" %in% Spectra::spectraVariables(x))) {
         stop("Missing 'sequence' in Spectra::spectraVariables(x)")
@@ -200,10 +206,12 @@ plotSpectraPTM <- function(x, deltaMz = TRUE, ppm = 20,
 
     if (length(main) != nsp) main <- rep(main[1], nsp)
 
-    labels <- labelFragments(x, ppm = ppm, what = "ion", ...)
+    labels <- labelFragments(x, ppm = ppm, what = "ion",
+        addCarbamidomethyl = addCarbamidomethyl, ...)
 
     if (deltaMz) { ## Generate deltaMzData labels for .plot_single_spectrum_PTM
-        deltaMzData <- labelFragments(x, ppm = ppm, what = "mz", ...)
+        deltaMzData <- labelFragments(x, ppm = ppm, what = "mz",
+            addCarbamidomethyl = addCarbamidomethyl, ...)
         layout_matrix <- .make_layout_matrix(length(labels))
         layout(layout_matrix,
                heights = rep(c(5, 1), length.out = nrow(layout_matrix)))

--- a/man/plotSpectraPTM.Rd
+++ b/man/plotSpectraPTM.Rd
@@ -87,10 +87,14 @@ plotting. \code{NULL} by default (no fixed modifications applied).}
 \item{variableModifications}{Named \code{numeric} or \code{character}, passed to
 \code{PTMods::addVariableModifications()}. Each unique combination of
 variable modifications generates a separate copy of the corresponding
-spectrum. \code{NULL} by default (no variable modifications applied).}
+spectrum. \code{NULL} by default (no variable modifications applied). If
+carbamidomethylation should be applied as a variable modification, do
+call an extra parameter \code{addCarbamidomethylation = FALSE}. For more
+details on this, see the appropriate vignette by running
+\code{vignette("Fragments", package = "PSMatch")}}
 
 \item{...}{additional parameters to be passed to the \code{labelFragments()}
-function.}
+and as such, \code{calculateFragments()} functions.}
 }
 \value{
 Creates a plot depicting an MS/MS-MS spectrum.

--- a/man/plotSpectraPTM.Rd
+++ b/man/plotSpectraPTM.Rd
@@ -94,7 +94,7 @@ spectrum. \code{NULL} by default (no variable modifications applied).}
 carbamidomethylation as a fixed modification unless carbamidomethyl is
 already present in the given sequences.
 If carbamidomethylation should be applied as a variable modification, do
-call an extra parameter \code{addCarbamidomethylation = FALSE}. For more
+set \code{addCarbamidomethylation = FALSE}. For more
 details on this, see the appropriate vignette by running
 `vignette("Fragments", package = "PSMatch")}
 

--- a/man/plotSpectraPTM.Rd
+++ b/man/plotSpectraPTM.Rd
@@ -24,6 +24,7 @@ plotSpectraPTM(
   USI = TRUE,
   fixedModifications = NULL,
   variableModifications = NULL,
+  addCarbamidomethyl = TRUE,
   ...
 )
 }
@@ -87,11 +88,15 @@ plotting. \code{NULL} by default (no fixed modifications applied).}
 \item{variableModifications}{Named \code{numeric} or \code{character}, passed to
 \code{PTMods::addVariableModifications()}. Each unique combination of
 variable modifications generates a separate copy of the corresponding
-spectrum. \code{NULL} by default (no variable modifications applied). If
-carbamidomethylation should be applied as a variable modification, do
+spectrum. \code{NULL} by default (no variable modifications applied).}
+
+\item{addCarbamidomethyl}{logical(1L) set to \code{TRUE} by default. Applies
+carbamidomethylation as a fixed modification unless carbamidomethyl is
+already present in the given sequences.
+If carbamidomethylation should be applied as a variable modification, do
 call an extra parameter \code{addCarbamidomethylation = FALSE}. For more
 details on this, see the appropriate vignette by running
-\code{vignette("Fragments", package = "PSMatch")}}
+`vignette("Fragments", package = "PSMatch")}
 
 \item{...}{additional parameters to be passed to the \code{labelFragments()}
 and as such, \code{calculateFragments()} functions.}

--- a/man/plotSpectraPTM.Rd
+++ b/man/plotSpectraPTM.Rd
@@ -99,7 +99,7 @@ details on this, see the appropriate vignette by running
 `vignette("Fragments", package = "PSMatch")}
 
 \item{...}{additional parameters to be passed to the \code{labelFragments()}
-and as such, \code{calculateFragments()} functions.}
+and \code{calculateFragments()} functions.}
 }
 \value{
 Creates a plot depicting an MS/MS-MS spectrum.

--- a/vignettes/Fragments.Rmd
+++ b/vignettes/Fragments.Rmd
@@ -85,20 +85,23 @@ sp1158$sequence
 
 The `calculateFragments()` simply takes a peptide sequence as input
 and returns a `data.frame` with the fragment sequences, M/Z, ion type,
-charge, position and the peptide sequence of the parent ion.
+charge, position and the peptide sequence of the parent ion. By default,
+carbamidomethylation of cysteines is applied, but it can be turned off with the
+parameter `addCarbamidomethyl = FALSE`.
 
 ```{r}
-calculateFragments(sp1158$sequence[2])
+calculateFragments(sp1158$sequence[2], addCarbamidomethyl = FALSE)
 ```
 
 The function also allows to generate fragment sequences with fixed and/or
 variable modifications. To do so, ideally add modifications using the `PTMods`
-package. For instance, for `PTMods::addFixedModifications()`, by default,
-`fixedModifications = c(C = 57.02146)` for carbamidomethylation of cysteines.
+package functions `PTMods::addFixedModifications()` and
+`PTMods::addVariableModifications()`.
 
-With variable modifications, multiple sets of fragments are generated. The
-fragments can be traced to their parent ion by checking the `peptide` column.
-A fragment can have multiple modifications.
+With variable modifications, multiple sets of fragments are generated based on
+the peptide-modifications combinations available. The fragments can be traced
+to their parent ion by checking the `peptide` column. A fragment can have
+multiple modifications.
 
 ```{r}
 var_seq <- PTMods::addVariableModifications(sp1158$sequence[2],
@@ -108,10 +111,10 @@ var_seq <- PTMods::addVariableModifications(sp1158$sequence[2],
 calculateFragments(var_seq)
 ```
 
-Additional parameters can limit the maximum number of allowed modifications in
-`addVariableModifications()`, or the type of ions produced or the charge
-applied in `calculateFragments`. See `?calculateFragments` and
-`?PTMods::addVariableModifications` for more details on those.
+Additional parameters can alter the type of ions produced or the charge applied
+in `calculateFragments`. See `?calculateFragments` for more details on those.
+See the `PTMods` functions for how to handle/apply/change the annotation style
+of modifications on your sequences.
 
 # Visualising fragment ions
 
@@ -129,12 +132,12 @@ b- and y-ion fragment sequences.
 Labels are automatically applied based on the `sequence` defined in the
 `spectraVariables`. Additionally, variable or fixed modifications such as
 carbamidomethylation of cysteines can be added using the
-`variableModifications` and `fixedModifications` parameters.
+`variableModifications` and `fixedModifications` parameters. Remember, by
+default, carbamidomethylation is applied on all sequences.
 
 ```{r}
 dataOrigin(sp1158)[2] <- "TMT_Erwinia" ## Reduces the mzspec text
 plotSpectraPTM(sp1158[2],
-    main = "Scan 1158 with carbamidomethylation",
     fixedModifications = c(C = "Carbamidomethyl")
 )
 ```
@@ -145,12 +148,19 @@ is applied (as above) compared to no modifications at all.
 ```{r}
 plotSpectraPTM(sp1158[2],
     variableModifications = c(C = "Carbamidomethyl"),
-    main = "Scan 1158 without modifications"
+    addCarbamidomethyl = FALSE, ## Remove carbamidomethyl by default
+    asp = 1/2,
+    deltaMz = FALSE,
+    main = c("Scan 1158 without carbamidomethyl", "Scan 1158 with carbamidomethyl")
 )
 ```
 
 As glycine has the same mass as carbamidomethylation, the b7 and b8 ions are
-overlapping in both spectra).
+overlapping in both spectra.
+
+The spectra displayed in this vignette might be overlapping due to the
+restricted windows. For a better visualisation, we suggest running the code
+locally.
 
 For more details on what `plotSpectraPTM()` can do, run `?plotSpectraPTM`.
 

--- a/vignettes/Fragments.Rmd
+++ b/vignettes/Fragments.Rmd
@@ -94,9 +94,9 @@ calculateFragments(sp1158$sequence[2], addCarbamidomethyl = FALSE)
 ```
 
 The function also allows to generate fragment sequences with fixed and/or
-variable modifications. To do so, ideally add modifications using the `PTMods`
-package functions `PTMods::addFixedModifications()` and
-`PTMods::addVariableModifications()`.
+variable modifications using the `PTMods::addFixedModifications()` and
+`PTMods::addVariableModifications()` functions from the `r
+BiocStyle::Biocpkg("PTMods")` package.
 
 With variable modifications, multiple sets of fragments are generated based on
 the peptide-modifications combinations available. The fragments can be traced
@@ -113,8 +113,11 @@ calculateFragments(var_seq)
 
 Additional parameters can alter the type of ions produced or the charge applied
 in `calculateFragments`. See `?calculateFragments` for more details on those.
-See the `PTMods` functions for how to handle/apply/change the annotation style
-of modifications on your sequences.
+See the `PTMods` functions (`?PTMods::convertAnnotation`,
+`?PTMods::getCanonicalSequence`, `?PTMods::combineModifications`) for how to
+handle/apply/change the annotation style of modifications on your sequences or
+check out the corresponding vignette with `vignette("PTMods", package =
+"PTMods")`.
 
 # Visualising fragment ions
 


### PR DESCRIPTION
As the title suggests, the example spectra using `plotSpectraPTM` in the vignette had an error due to a misuse of the `addCarbamidomethyl = TRUE` by default in `calculateFragments()`. 

This PR corrects the example, and adds a bit more clarification on the subject. 